### PR TITLE
use the newer galaxy scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -896,7 +896,7 @@ limitations under the License.
       <properties>
         <galaxy.webroot>ROOT</galaxy.webroot>
         <galaxy.skip.deploy>false</galaxy.skip.deploy>
-        <galaxy.scripts.version>1.1.0-SNAPSHOT</galaxy.scripts.version>
+        <galaxy.scripts.version>1.1.0</galaxy.scripts.version>
         <galaxy.packaging>standalone</galaxy.packaging>
         <galaxy.launcher>${galaxy.packaging}</galaxy.launcher>
         <galaxy.jvm>1.6.0</galaxy.jvm>


### PR DESCRIPTION
This is the actual diff against the 13 release:

```
--- /home/henning/.m2/repository/com/nesscomputing/ness-oss-parent/13/ness-oss-parent-13.pom    2012-07- 09 14:50:53.948675437 -0700
+++ pom.xml 2012-07-12 13:38:31.213707114 -0700
@@ -27,7 +27,7 @@
   <groupId>com.nesscomputing</groupId>
   <artifactId>ness-oss-parent</artifactId>
   <packaging>pom</packaging>
-  <version>13</version>
+  <version>14-SNAPSHOT</version>
   <name>ness-oss-parent</name>
   <description>This is the parent POM for Ness open source maven projects.</description>
   <url>https://opensource.nesscomputing.com/</url>
@@ -896,9 +896,10 @@
       <properties>
         <galaxy.webroot>ROOT</galaxy.webroot>
         <galaxy.skip.deploy>false</galaxy.skip.deploy>
-        <galaxy.scripts.version>1.0.0</galaxy.scripts.version>
+        <galaxy.scripts.version>1.1.0</galaxy.scripts.version>
         <galaxy.packaging>standalone</galaxy.packaging>
         <galaxy.launcher>${galaxy.packaging}</galaxy.launcher>
+        <galaxy.jvm>1.6.0</galaxy.jvm>
       </properties>
       <build>
     <plugins>
```
