### PR TITLE
Move project dependency checks to "validate" phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,21 @@ limitations under the License.
                     <ignore />
                   </action>
                 </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[0,)</versionRange>
+                    <goals>
+                      <goal>analyze-dep-mgt</goal>
+                      <goal>analyze-duplicate</goal>
+                      <goal>analyze-only</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>


### PR DESCRIPTION
Hopefully this will cause banned dependencies or mismatched dependency versions to manifest themselves as explicit errors rather than obscured test failures.
